### PR TITLE
Resolution for "Error: failed to run custom build command for ring v0.14.6 …"

### DIFF
--- a/secret_contracts/demonstration/Cargo.toml
+++ b/secret_contracts/demonstration/Cargo.toml
@@ -5,10 +5,10 @@ version = "0.1.0"
 [dependencies]
 eng-wasm = "0.1.3"
 eng-wasm-derive = "0.1.3"
-enigma-crypto = { git = "https://github.com/enigmampc/enigma-core.git", version = "0.2.0" }
-serde = "1.0.84"
-serde_derive = "1.0.98"
+enigma-crypto = { git = "https://github.com/enigmampc/enigma-core.git", default-features = false, features = ["asymmetric", "hash"] }
 rustc-hex = "2.0.1"
+serde_derive = "1.0.84"
+serde = "1.0.84"
 
 [lib]
 crate-type = ["cdylib"]

--- a/secret_contracts/demonstration/src/lib.rs
+++ b/secret_contracts/demonstration/src/lib.rs
@@ -31,7 +31,7 @@ pub trait ContractInterface {
 
 impl Contract {
   fn get_state() -> State {
-    match read_state!(STATE) {
+    match read_state!(STATE).unwrap() {
       Some(state) => state,
       None => panic!("state should already exist"),
     }
@@ -41,10 +41,8 @@ impl Contract {
 pub struct Contract;
 impl ContractInterface for Contract {
   fn construct() -> () {
-    let key_pair = KeyPair::new().unwrap();
-
     write_state!(STATE => State {
-      private_key: key_pair.get_privkey(),
+      private_key: generate_key(),
       nonce: U256::from(0)
     });
   }


### PR DESCRIPTION
Hey @nionis, 

See the changes I made to resolve the `ring` build error. I used Enigma's encryption example secret contract as a reference: https://github.com/enigmampc/enigma-core/tree/develop/examples/eng_wasm_contracts/encryption.

The example encryption ESC uses the eng_wasm crate's `generate_key()` to create a new random encryption key. 